### PR TITLE
update aspect ratio scaling and drawing

### DIFF
--- a/src/lib/p5/P5Wrapper.svelte
+++ b/src/lib/p5/P5Wrapper.svelte
@@ -1,273 +1,261 @@
 <script lang="ts">
-  import P5, { type Sketch } from 'p5-svelte';
-  import type p5 from 'p5';
-  import { onMount } from 'svelte';
-  import { drawingConfig } from '../stores/drawingConfig';
-  import { drawingState, createNewPath, handleTimeJump } from '../stores/drawingState';
-  import { setupDrawing, drawPaths } from './features/drawing';
-  import { setupVideo } from './features/video';
-  import VideoControls from '../components/video/VideoControls.svelte';
+    import P5, { type Sketch } from "p5-svelte";
+    import type p5 from "p5";
+    import { onMount } from "svelte";
+    import { drawingConfig } from "../stores/drawingConfig";
+    import { drawingState, createNewPath, handleTimeJump } from "../stores/drawingState";
+    import { setupDrawing, drawPaths } from "./features/drawing";
+    import { setupVideo } from "./features/video";
+    import VideoControls from "../components/video/VideoControls.svelte";
+    import { getFittedImageDisplayRect } from "$lib/utils/drawingUtils";
 
-  let containerDiv: HTMLDivElement;
-  let width = 800;
-  let height = 400;
-  let isDraggingSplitter = false;
-  let videoElement: p5.Element | null = null;
-  let p5Instance: p5;
-  let lastVideoTime = 0;
-  const colors = ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#FF00FF', '#00FFFF'];
+    let containerDiv: HTMLDivElement;
+    let width = 800;
+    let height = 400;
+    let isDraggingSplitter = false;
+    let videoElement: p5.Element | null = null;
+    let p5Instance: p5;
+    let lastVideoTime = 0;
+    const colors = ["#FF0000", "#00FF00", "#0000FF", "#FFFF00", "#FF00FF", "#00FFFF"];
 
-  $: videoHtmlElement = videoElement ? (videoElement as any).elt : null;
+    $: videoHtmlElement = videoElement ? (videoElement as any).elt : null;
 
-  function handleSplitterDrag(e: MouseEvent) {
-    if (isDraggingSplitter) {
-      e.preventDefault();
-      e.stopPropagation();
+    function handleSplitterDrag(e: MouseEvent) {
+        if (isDraggingSplitter) {
+            e.preventDefault();
+            e.stopPropagation();
 
-      const rect = containerDiv.getBoundingClientRect();
-      const position = ((e.clientX - rect.left) / rect.width) * 100;
-      const minVideoWidth = 30;
-      const minImageWidth = 30;
-      const constrainedPosition = Math.min(
-        Math.max(position, minVideoWidth),
-        100 - minImageWidth
-      );
+            const rect = containerDiv.getBoundingClientRect();
+            const position = ((e.clientX - rect.left) / rect.width) * 100;
+            const minVideoWidth = 30;
+            const minImageWidth = 30;
+            const constrainedPosition = Math.min(Math.max(position, minVideoWidth), 100 - minImageWidth);
 
-      drawingConfig.update(config => ({
-        ...config,
-        splitPosition: constrainedPosition
-      }));
-    }
-  }
-
-  function handleSplitterEnd() {
-    isDraggingSplitter = false;
-    if (p5Instance) {
-      p5Instance.loop();
-    }
-  }
-
-  onMount(() => {
-    window.addEventListener('keydown', (e) => {
-      if (!videoHtmlElement) return;
-
-      if (e.code === 'Space') {
-        e.preventDefault();
-        if (videoHtmlElement.paused) {
-          videoHtmlElement.play();
-        } else {
-          videoHtmlElement.pause();
-        }
-      } else if (e.key.toLowerCase() === 'f') {
-        e.preventDefault();
-        handleTimeJump(true, videoHtmlElement);
-      } else if (e.key.toLowerCase() === 'r') {
-        e.preventDefault();
-        handleTimeJump(false, videoHtmlElement);
-      }
-    });
-
-    const updateDimensions = () => {
-      height = window.innerHeight - 64;
-      width = containerDiv.clientWidth;
-      if (p5Instance) {
-        p5Instance.resizeCanvas(width, height);
-      }
-    };
-
-    window.addEventListener('resize', updateDimensions);
-    updateDimensions();
-    return () => window.removeEventListener('resize', updateDimensions);
-  });
-
-  const sketch: Sketch = (p5: p5) => {
-    p5Instance = p5;
-    const { handleMousePressed, handleDrawing } = setupDrawing(p5);
-
-    p5.setup = () => {
-      const canvas = p5.createCanvas(width, height);
-      canvas.parent(containerDiv);
-      p5.strokeCap(p5.ROUND);
-      p5.strokeJoin(p5.ROUND);
-
-      if (p5Instance) {
-        p5Instance.noLoop();
-      }
-    };
-
-    p5.draw = () => {
-      p5.background(255);
-      const splitX = (width * $drawingConfig.splitPosition) / 100;
-
-      if (videoElement) {
-        const { updateVideoTime, drawVideo, checkVideoEnd } = setupVideo(p5);
-        lastVideoTime = updateVideoTime(videoElement, lastVideoTime);
-        checkVideoEnd(videoElement);
-        drawVideo(p5, videoElement);
-      }
-
-      const currentImage = $drawingState.imageElement;
-      if (currentImage && $drawingState.imageWidth > 0) {
-        const aspectRatio = $drawingState.imageWidth / $drawingState.imageHeight;
-        const displayHeight = Math.min(height, (width - splitX) / aspectRatio);
-        p5.image(currentImage, splitX, 0, width - splitX, displayHeight);
-      }
-
-      handleDrawing();
-      drawPaths(p5);
-    };
-
-    p5.mousePressed = () => {
-      if (!isDraggingSplitter) {
-        handleMousePressed(videoHtmlElement);
-      }
-    };
-
-    if (p5Instance) {
-      p5Instance.loop();
-    }
-  };
-
-  export function setVideo(video: HTMLVideoElement) {
-    lastVideoTime = 0;
-
-    drawingState.update(state => ({
-      ...state,
-      videoTime: 0
-    }));
-
-    if (videoElement) {
-      try {
-        const videoElt = (videoElement as any).elt;
-        if (videoElt) {
-          videoElt.pause();
-          videoElt.currentTime = 0;
-        }
-        (videoElement as any).remove();
-      } catch (e) {
-        console.warn("Error cleaning up previous video:", e);
-      }
-    }
-
-    video.loop = false;
-
-    const { setVideo: setupP5Video } = setupVideo(p5Instance);
-    videoElement = setupP5Video(video);
-
-    if (videoElement) {
-      (videoElement as any).elt.loop = false;
-
-      if (p5Instance) {
-            p5Instance.redraw();
-            clearDrawing();
+            drawingConfig.update((config) => ({
+                ...config,
+                splitPosition: constrainedPosition,
+            }));
         }
     }
 
-    createNewPath(colors[0]);
-  }
-
-  export function setImage(image: HTMLImageElement) {
-    p5Instance.loadImage(image.src, (p5Img: p5.Image) => {
-      drawingState.update(state => ({
-        ...state,
-        imageWidth: image.width,
-        imageHeight: image.height,
-        imageElement: p5Img
-      }));
-    });
-  }
-
-  export function startNewPath() {
-    if (videoHtmlElement) {
-      videoHtmlElement.currentTime = 0;
-      videoHtmlElement.pause();
-
-      const currentPathCount = $drawingState.paths.length;
-      const newColor = colors[currentPathCount % colors.length];
-
-      createNewPath(newColor);
-
-      drawingState.update(state => ({
-        ...state,
-        shouldTrackMouse: false,
-        isDrawing: false,
-        isVideoPlaying: false
-      }));
-    }
-  }
-
-  export function exportPath() {
-    const paths = $drawingState.paths;
-    paths.forEach((path, index) => {
-      if (path.points.length === 0) return;
-
-      const csv = path.points.map(p => `${p.x},${p.y},${p.time}`).join('\n');
-      const blob = new Blob([`x,y,time\n${csv}`], { type: 'text/csv' });
-      const url = URL.createObjectURL(blob);
-
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `path-${index + 1}.csv`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-
-      URL.revokeObjectURL(url);
-    });
-  }
-
-  export function clearDrawing() {
-    if (videoHtmlElement) {
-      videoHtmlElement.currentTime = 0;
-      videoHtmlElement.pause();
+    function handleSplitterEnd() {
+        isDraggingSplitter = false;
+        if (p5Instance) {
+            p5Instance.loop();
+        }
     }
 
-    drawingState.update(state => ({
-      ...state,
-      paths: [],
-      currentPathId: 0,
-      shouldTrackMouse: false,
-      isDrawing: false,
-      isVideoPlaying: false
-    }));
+    onMount(() => {
+        window.addEventListener("keydown", (e) => {
+            if (!videoHtmlElement) return;
 
-    createNewPath(colors[0]);
-  }
+            if (e.code === "Space") {
+                e.preventDefault();
+                if (videoHtmlElement.paused) {
+                    videoHtmlElement.play();
+                } else {
+                    videoHtmlElement.pause();
+                }
+            } else if (e.key.toLowerCase() === "f") {
+                e.preventDefault();
+                handleTimeJump(true, videoHtmlElement);
+            } else if (e.key.toLowerCase() === "r") {
+                e.preventDefault();
+                handleTimeJump(false, videoHtmlElement);
+            }
+        });
 
-  $: if (containerDiv && $drawingConfig) {
-    containerDiv.style.setProperty('--split-width', `${$drawingConfig.splitPosition}%`);
-  }
+        const updateDimensions = () => {
+            height = window.innerHeight - 64;
+            width = containerDiv.clientWidth;
+            if (p5Instance) {
+                p5Instance.resizeCanvas(width, height);
+            }
+        };
+
+        window.addEventListener("resize", updateDimensions);
+        updateDimensions();
+        return () => window.removeEventListener("resize", updateDimensions);
+    });
+
+    const sketch: Sketch = (p5: p5) => {
+        p5Instance = p5;
+        const { handleMousePressed, handleDrawing } = setupDrawing(p5);
+
+        p5.setup = () => {
+            const canvas = p5.createCanvas(width, height);
+            canvas.parent(containerDiv);
+            p5.strokeCap(p5.ROUND);
+            p5.strokeJoin(p5.ROUND);
+
+            if (p5Instance) {
+                p5Instance.noLoop();
+            }
+        };
+
+        p5.draw = () => {
+            p5.background(255);
+
+            if (videoElement) {
+                const { updateVideoTime, drawVideo, checkVideoEnd } = setupVideo(p5);
+                lastVideoTime = updateVideoTime(videoElement, lastVideoTime);
+                checkVideoEnd(videoElement);
+                drawVideo(p5, videoElement);
+            }
+
+            const img = $drawingState.imageElement;
+            const imgW = $drawingState.imageWidth;
+            const imgH = $drawingState.imageHeight;
+
+            if (img && imgW && imgH) {
+                const r = getFittedImageDisplayRect(p5, $drawingConfig.splitPosition, imgW, imgH);
+                p5.image(img, r.x, r.y, r.w, r.h);
+            }
+
+            handleDrawing();
+            drawPaths(p5);
+        };
+
+        p5.mousePressed = () => {
+            if (!isDraggingSplitter) {
+                handleMousePressed(videoHtmlElement);
+            }
+        };
+
+        if (p5Instance) {
+            p5Instance.loop();
+        }
+    };
+
+    export function setVideo(video: HTMLVideoElement) {
+        lastVideoTime = 0;
+
+        drawingState.update((state) => ({
+            ...state,
+            videoTime: 0,
+        }));
+
+        if (videoElement) {
+            try {
+                const videoElt = (videoElement as any).elt;
+                if (videoElt) {
+                    videoElt.pause();
+                    videoElt.currentTime = 0;
+                }
+                (videoElement as any).remove();
+            } catch (e) {
+                console.warn("Error cleaning up previous video:", e);
+            }
+        }
+
+        video.loop = false;
+
+        const { setVideo: setupP5Video } = setupVideo(p5Instance);
+        videoElement = setupP5Video(video);
+
+        if (videoElement) {
+            (videoElement as any).elt.loop = false;
+
+            if (p5Instance) {
+                p5Instance.redraw();
+                clearDrawing();
+            }
+        }
+
+        createNewPath(colors[0]);
+    }
+
+    export function setImage(image: HTMLImageElement) {
+        p5Instance.loadImage(image.src, (p5Img: p5.Image) => {
+            drawingState.update((state) => ({
+                ...state,
+                imageWidth: image.width,
+                imageHeight: image.height,
+                imageElement: p5Img,
+            }));
+        });
+    }
+
+    export function startNewPath() {
+        if (videoHtmlElement) {
+            videoHtmlElement.currentTime = 0;
+            videoHtmlElement.pause();
+
+            const currentPathCount = $drawingState.paths.length;
+            const newColor = colors[currentPathCount % colors.length];
+
+            createNewPath(newColor);
+
+            drawingState.update((state) => ({
+                ...state,
+                shouldTrackMouse: false,
+                isDrawing: false,
+                isVideoPlaying: false,
+            }));
+        }
+    }
+
+    export function exportPath() {
+        const paths = $drawingState.paths;
+        paths.forEach((path, index) => {
+            if (path.points.length === 0) return;
+
+            const csv = path.points.map((p) => `${p.x},${p.y},${p.time}`).join("\n");
+            const blob = new Blob([`x,y,time\n${csv}`], { type: "text/csv" });
+            const url = URL.createObjectURL(blob);
+
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `path-${index + 1}.csv`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+
+            URL.revokeObjectURL(url);
+        });
+    }
+
+    export function clearDrawing() {
+        if (videoHtmlElement) {
+            videoHtmlElement.currentTime = 0;
+            videoHtmlElement.pause();
+        }
+
+        drawingState.update((state) => ({
+            ...state,
+            paths: [],
+            currentPathId: 0,
+            shouldTrackMouse: false,
+            isDrawing: false,
+            isVideoPlaying: false,
+        }));
+
+        createNewPath(colors[0]);
+    }
+
+    $: if (containerDiv && $drawingConfig) {
+        containerDiv.style.setProperty("--split-width", `${$drawingConfig.splitPosition}%`);
+    }
 </script>
 
-<div
-  bind:this={containerDiv}
-  class="relative w-full h-[calc(100vh-64px)]"
-  on:mousemove={handleSplitterDrag}
-  on:mouseup={handleSplitterEnd}
-  on:mouseleave={handleSplitterEnd}
-  role="application"
-  aria-label="Drawing Canvas"
->
-  <P5 {sketch} />
+<div bind:this={containerDiv} class="relative w-full h-[calc(100vh-64px)]" on:mousemove={handleSplitterDrag} on:mouseup={handleSplitterEnd} on:mouseleave={handleSplitterEnd} role="application" aria-label="Drawing Canvas">
+    <P5 {sketch} />
 
-  <div
-    class="absolute top-0 bottom-0 w-8 bg-transparent cursor-col-resize hover:bg-black/5"
-    style="left: calc({$drawingConfig.splitPosition}% - 16px)"
-    on:mousedown={(e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      isDraggingSplitter = true;
-    }}
-    role="separator"
-    aria-label="Resize panels"
-  >
     <div
-      class="absolute top-0 bottom-0 w-1 bg-gray-400 hover:bg-blue-500 transition-colors"
-      style="left: 50%"
-    />
-  </div>
+        class="absolute top-0 bottom-0 w-8 bg-transparent cursor-col-resize hover:bg-black/5"
+        style="left: calc({$drawingConfig.splitPosition}% - 16px)"
+        on:mousedown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            isDraggingSplitter = true;
+        }}
+        role="separator"
+        aria-label="Resize panels"
+    >
+        <div class="absolute top-0 bottom-0 w-1 bg-gray-400 hover:bg-blue-500 transition-colors" style="left: 50%" />
+    </div>
 
-  {#if videoHtmlElement}
-    <VideoControls videoElement={videoHtmlElement} />
-  {/if}
+    {#if videoHtmlElement}
+        <VideoControls videoElement={videoHtmlElement} />
+    {/if}
 </div>

--- a/src/lib/p5/features/drawing.ts
+++ b/src/lib/p5/features/drawing.ts
@@ -1,145 +1,140 @@
 import type p5 from "p5";
 import type { Point } from "../types/sketch";
 import { get } from "svelte/store";
-import {
-  drawingState,
-  addPointToCurrentPath,
-  toggleDrawing,
-} from "../../stores/drawingState";
+import { drawingState, addPointToCurrentPath, toggleDrawing } from "../../stores/drawingState";
 import { drawingConfig } from "../../stores/drawingConfig";
-import {
-  isInDrawableArea,
-  convertToImageCoordinates,
-} from "../../utils/drawingUtils";
+import { isInDrawableArea, convertToImageCoordinates } from "../../utils/drawingUtils";
+import { getFittedImageDisplayRect } from "../../utils/drawingUtils";
 
 class TimeBasedSampler {
-  private lastSampleTime: number = 0;
+    private lastSampleTime: number = 0;
 
-  constructor(private sampleInterval: number) {}
+    constructor(private sampleInterval: number) {}
 
-  shouldSample(currentTime: number): boolean {
-    if (currentTime - this.lastSampleTime >= this.sampleInterval) {
-      this.lastSampleTime = currentTime;
-      return true;
+    shouldSample(currentTime: number): boolean {
+        if (currentTime - this.lastSampleTime >= this.sampleInterval) {
+            this.lastSampleTime = currentTime;
+            return true;
+        }
+        return false;
     }
-    return false;
-  }
 
-  reset() {
-    this.lastSampleTime = 0;
-  }
+    reset() {
+        this.lastSampleTime = 0;
+    }
 }
 
 export function setupDrawing(p5: p5) {
-  const sampler = new TimeBasedSampler(get(drawingConfig).pollingRate / 1000);
+    const sampler = new TimeBasedSampler(get(drawingConfig).pollingRate / 1000);
 
-  drawingConfig.subscribe((config) => {
-    sampler.reset();
-  });
-
-  const addCurrentPoint = () => {
-    const state = get(drawingState);
-    if (!state.shouldTrackMouse) return;
-
-    if (isInDrawableArea(p5, p5.mouseX, p5.mouseY)) {
-      if (sampler.shouldSample(state.videoTime)) {
-        const coords = convertToImageCoordinates(p5, p5.mouseX, p5.mouseY);
-        const point: Point = {
-          ...coords,
-          time: state.videoTime,
-          pathId: state.currentPathId,
-        };
-        addPointToCurrentPath(point);
-      }
-    }
-  };
-
-  const handleMousePressed = (videoElement?: HTMLVideoElement) => {
-    if (isInDrawableArea(p5, p5.mouseX, p5.mouseY)) {
-      const state = get(drawingState);
-
-      if (
-        videoElement &&
-        videoElement.currentTime >= videoElement.duration - 0.1
-      ) {
-        return;
-      }
-
-      if (!state.shouldTrackMouse) {
+    drawingConfig.subscribe((config) => {
         sampler.reset();
-      }
+    });
 
-      toggleDrawing(videoElement);
-    }
-  };
+    const addCurrentPoint = () => {
+        const state = get(drawingState);
+        if (!state.shouldTrackMouse) return;
 
-  const handleDrawing = () => {
-    const state = get(drawingState);
-    if (state.shouldTrackMouse) {
-      addCurrentPoint();
-    }
-  };
+        if (isInDrawableArea(p5, p5.mouseX, p5.mouseY)) {
+            if (sampler.shouldSample(state.videoTime)) {
+                const coords = convertToImageCoordinates(p5, p5.mouseX, p5.mouseY);
+                const point: Point = {
+                    ...coords,
+                    time: state.videoTime,
+                    pathId: state.currentPathId,
+                };
+                addPointToCurrentPath(point);
+            }
+        }
+    };
 
-  return {
-    handleMousePressed,
-    handleDrawing,
-  };
+    const handleMousePressed = (videoElement?: HTMLVideoElement) => {
+        if (isInDrawableArea(p5, p5.mouseX, p5.mouseY)) {
+            const state = get(drawingState);
+
+            if (videoElement && videoElement.currentTime >= videoElement.duration - 0.1) {
+                return;
+            }
+
+            if (!state.shouldTrackMouse) {
+                sampler.reset();
+            }
+
+            toggleDrawing(videoElement);
+        }
+    };
+
+    const handleDrawing = () => {
+        const state = get(drawingState);
+        if (state.shouldTrackMouse) {
+            addCurrentPoint();
+        }
+    };
+
+    return {
+        handleMousePressed,
+        handleDrawing,
+    };
 }
 
 export function drawPaths(p5: p5) {
-  const state = get(drawingState);
-  const config = get(drawingConfig);
-  const splitX = (p5.width * config.splitPosition) / 100;
-  const drawingAreaWidth = p5.width - splitX;
-  const drawingAreaHeight = p5.height;
-  const ENDPOINT_MARKER_SIZE = 15;
+    const state = get(drawingState);
+    const config = get(drawingConfig);
 
-  p5.push();
+    const imgW = state.imageWidth;
+    const imgH = state.imageHeight;
+    if (!imgW || !imgH) return;
 
-  state.paths.forEach((path) => {
-    p5.strokeWeight(config.strokeWeight);
-    p5.stroke(path.color);
-    p5.noFill();
+    // Same rect used for p5.image(...)
+    const r = getFittedImageDisplayRect(p5, config.splitPosition, imgW, imgH);
 
-    if (path.points.length > 1) {
-      p5.beginShape();
-      path.points.forEach((point) => {
-        const displayX =
-          splitX + (point.x * drawingAreaWidth) / state.imageWidth;
-        const displayY = (point.y * drawingAreaHeight) / state.imageHeight;
-        p5.vertex(displayX, displayY);
-      });
-      p5.endShape();
+    const ENDPOINT_MARKER_SIZE = 15;
 
-      if (path.pathId === state.currentPathId && !state.shouldTrackMouse) {
-        const lastPoint = path.points[path.points.length - 1];
-        const displayX =
-          splitX + (lastPoint.x * drawingAreaWidth) / state.imageWidth;
-        const displayY = (lastPoint.y * drawingAreaHeight) / state.imageHeight;
+    p5.push();
 
-        const pulseScale = (Math.sin(p5.frameCount * 0.05) + 1) * 0.25 + 0.5;
+    state.paths.forEach((path) => {
+        p5.strokeWeight(config.strokeWeight);
+        p5.stroke(path.color);
+        p5.noFill();
 
-        p5.noStroke();
-        for (let i = 4; i > 0; i--) {
-          const alpha = 50 - i * 10;
-          p5.fill(255, 0, 0, alpha);
-          const size = ENDPOINT_MARKER_SIZE * (1.5 + i * 0.5) * pulseScale;
-          p5.circle(displayX, displayY, size);
+        const toDisplay = (pt: { x: number; y: number }) => ({
+            x: r.x + (pt.x / imgW) * r.w,
+            y: r.y + (pt.y / imgH) * r.h,
+        });
+
+        if (path.points.length > 1) {
+            p5.beginShape();
+            path.points.forEach((pt) => {
+                const { x, y } = toDisplay(pt);
+                p5.vertex(x, y);
+            });
+            p5.endShape();
+
+            // Pulsing endpoint for the active path
+            if (path.pathId === state.currentPathId && !state.shouldTrackMouse) {
+                const last = toDisplay(path.points[path.points.length - 1]);
+
+                const pulseScale = (Math.sin(p5.frameCount * 0.05) + 1) * 0.25 + 0.5;
+
+                p5.noStroke();
+                for (let i = 4; i > 0; i--) {
+                    const alpha = 50 - i * 10;
+                    p5.fill(255, 0, 0, alpha);
+                    const size = ENDPOINT_MARKER_SIZE * (1.5 + i * 0.5) * pulseScale;
+                    p5.circle(last.x, last.y, size);
+                }
+
+                p5.fill(255, 0, 0, 200);
+                p5.circle(last.x, last.y, ENDPOINT_MARKER_SIZE * pulseScale);
+
+                p5.fill(255);
+                p5.circle(last.x, last.y, ENDPOINT_MARKER_SIZE * 0.5 * pulseScale);
+            }
+        } else if (path.points.length === 1) {
+            const { x, y } = toDisplay(path.points[0]);
+            p5.point(x, y);
         }
+    });
 
-        p5.fill(255, 0, 0, 200);
-        p5.circle(displayX, displayY, ENDPOINT_MARKER_SIZE * pulseScale);
-
-        p5.fill(255);
-        p5.circle(displayX, displayY, ENDPOINT_MARKER_SIZE * 0.5 * pulseScale);
-      }
-    } else if (path.points.length === 1) {
-      const point = path.points[0];
-      const displayX = splitX + (point.x * drawingAreaWidth) / state.imageWidth;
-      const displayY = (point.y * drawingAreaHeight) / state.imageHeight;
-      p5.point(displayX, displayY);
-    }
-  });
-
-  p5.pop();
+    p5.pop();
 }

--- a/src/lib/utils/drawingUtils.ts
+++ b/src/lib/utils/drawingUtils.ts
@@ -1,32 +1,65 @@
+// src/utils/drawUtils.ts
 import type p5 from "p5";
 import { get } from "svelte/store";
 import { drawingConfig } from "../stores/drawingConfig";
 import { drawingState } from "../stores/drawingState";
 
-export function isInDrawableArea(p5: p5, x: number, y: number): boolean {
-  const config = get(drawingConfig);
-  const splitX = (p5.width * config.splitPosition) / 100;
+type Rect = { x: number; y: number; w: number; h: number };
 
-  return x > splitX && x < p5.width && y > 0 && y < p5.height;
+/**
+ * Compute the exact rect where the image is drawn on the right panel
+ * (aspect-fit / "contain", centered).
+ */
+export function getFittedImageDisplayRect(p5: p5, splitPosPct: number, imgW: number, imgH: number): Rect {
+    const splitX = (p5.width * splitPosPct) / 100;
+    const panelW = p5.width - splitX;
+    const panelH = p5.height;
+
+    const imgAspect = imgW / imgH;
+    const panelAspect = panelW / panelH;
+
+    if (imgAspect > panelAspect) {
+        // width-limited
+        const w = panelW;
+        const h = w / imgAspect;
+        return { x: splitX, y: (panelH - h) / 2, w, h };
+    } else {
+        // height-limited
+        const h = panelH;
+        const w = h * imgAspect;
+        return { x: splitX + (panelW - w) / 2, y: 0, w, h };
+    }
 }
 
+export function isInDrawableArea(p5: p5, x: number, y: number): boolean {
+    const config = get(drawingConfig);
+    const splitX = (p5.width * config.splitPosition) / 100;
+    return x > splitX && x < p5.width && y > 0 && y < p5.height;
+}
+
+/**
+ * Convert screen coords -> image pixel coords using the same rect as draw().
+ * Returns values clamped to image bounds.
+ */
 export function convertToImageCoordinates(p5: p5, x: number, y: number) {
-  const config = get(drawingConfig);
-  const state = get(drawingState);
-  const splitX = (p5.width * config.splitPosition) / 100;
+    const config = get(drawingConfig);
+    const state = get(drawingState);
 
-  const constrainedX = p5.constrain(x, splitX, p5.width);
-  const constrainedY = p5.constrain(y, 0, p5.height);
+    const imgW = state.imageWidth;
+    const imgH = state.imageHeight;
+    if (!imgW || !imgH) return { x: 0, y: 0 };
 
-  const drawingAreaWidth = p5.width - splitX;
-  const drawingAreaHeight = p5.height;
+    // Use the exact same math as the draw call
+    const r = getFittedImageDisplayRect(p5, config.splitPosition, imgW, imgH);
 
-  const imageX =
-    ((constrainedX - splitX) * state.imageWidth) / drawingAreaWidth;
-  const imageY = (constrainedY * state.imageHeight) / drawingAreaHeight;
+    const nx = (x - r.x) / r.w;
+    const ny = (y - r.y) / r.h;
 
-  return {
-    x: imageX,
-    y: imageY,
-  };
+    // Clamp normalized to [0,1] so clicks in letterbox map to edges
+    const clamp = (v: number) => Math.min(1, Math.max(0, v));
+
+    return {
+        x: clamp(nx) * imgW,
+        y: clamp(ny) * imgH,
+    };
 }


### PR DESCRIPTION
- @edw1nzhao can you give this a close review? I think this addresses the image scaling bug. Sorry that some of the formatting also changed when I saved, and is not related to the changes I made to address the bug.
- Specifically, changes I made are: 
- (1) Added getFittedImageDisplayRect utility to compute the correct display rectangle for images using aspect-fit scaling, ensuring both wide and tall images are rendered without distortion.
- (2) Updated drawPaths to map recorded image coordinates back to screen space using the fitted display rect, fixing misalignment when replaying paths on wide images.
- (3) Updated convertToImageCoordinates to use the same fitted display rect, ensuring coordinate recording and replay remain in sync across all image aspect ratios.

Sorry again for the formatting changes it made as well--I think this is just because these files had old formatting that doesn't match what we set in the repo?